### PR TITLE
human scale formatting of the deviation in cents

### DIFF
--- a/src/ui/tuner.rs
+++ b/src/ui/tuner.rs
@@ -59,7 +59,7 @@ impl fmt::Display for TunerUi {
             f.write_str(bar)?;
         };
 
-        write!(f, " {cents}")?;
+        write!(f, " {cents:3.0} cents")?;
 
         Ok(())
     }


### PR DESCRIPTION
truncate the decimals of the cents deviation as the human ear can't detect deviations of less than 5 cents